### PR TITLE
Fix a bug about small mask without polygon

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -638,6 +638,10 @@ class Visualizer:
                     self.draw_polygon(segment.reshape(-1, 2), color, alpha=alpha)
 
             if labels is not None:
+                # skip small mask without polygon
+                if len(masks[i].polygons) == 0:
+                   continue
+                
                 # first get a box
                 if boxes is not None:
                     x0, y0, x1, y1 = boxes[i]


### PR DESCRIPTION
Command line: python demo.py --config-file ../configs/COCO-PanopticSegmentation/panoptic_fpn_R_50_3x.yaml --input "$HOME/Datasets/COCO/2014/train2014/*.jpg" --opts MODEL.WEIGHTS detectron2://COCO-PanopticSegmentation/panoptic_fpn_R_50_3x/139514569/model_final_c10459.pkl

When processing the image `COCO_train2014_000000374538.jpg`, `labes=['person 55%', 'person 100%', 'skis 53%']`，the mask of `skis` is too small (two pixels only), which results in no polygon, and then `masks[i].bbox()` raises an exception `IndexError: list index out of range`.

This commit fixed this bug.

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

